### PR TITLE
CEW-224: Ensure that the correct total_amount is passed to the contribution create API

### DIFF
--- a/compucorp_commerce_civicrm.module
+++ b/compucorp_commerce_civicrm.module
@@ -637,15 +637,16 @@ function _compucorp_commerce_civicrm_add_contribution($cid, &$order) {
     }
   }
 
+  $totalAmount = _compucorp_commerce_civicrm_calculateTotalAmountForCiviAPI($order_total, $taxAmountTotal);
+
   $params = array(
     'contact_id' => $cid,
     'receive_date' => date('Ymd'),
-    'total_amount' => $order_total,
+    'total_amount' => $totalAmount,
     'financial_type_id' => variable_get('compucorp_commerce_civicrm_contribution_type'),
     'payment_instrument_id' => $payment_instrument_id,
     'non_deductible_amount' => 00.00,
     'fee_amount' => 00.00,
-    'net_amount' => $order_total + $taxAmountTotal,
     'tax_amount' => $taxAmountTotal,
     'trxn_id' => $txn_id,
     'invoice_id' => $order->order_id . '_dc',
@@ -669,6 +670,25 @@ function _compucorp_commerce_civicrm_add_contribution($cid, &$order) {
   }
 
   return TRUE;
+}
+
+/**
+ * CiviCRM API automatically calculates the tax on the
+ * total amount for versions <= 4.7.11 even if the tax amount
+ * is provided. This function ensures that the total amount
+ * for the contribution API is calculated correctly for different
+ * CiviCRM versions.
+ */
+function _compucorp_commerce_civicrm_calculateTotalAmountForCiviAPI($orderTotal, $taxAmount) {
+  $civicrmVersion = civicrm_api3('Domain', 'getvalue', array(
+    'return' => 'version',
+  ));
+  $totalAmount = $orderTotal;
+  if ($civicrmVersion <= '4.7.11') {
+    $totalAmount = $orderTotal - $taxAmount;
+  }
+
+  return $totalAmount;
 }
 
 /**
@@ -1160,11 +1180,12 @@ function _compucorp_commerce_civicrm_update_contribution($order) {
 
   $cid = _compucorp_commerce_civicrm_get_cid($order);
 
+  $totalAmount = _compucorp_commerce_civicrm_calculateTotalAmountForCiviAPI($order_total, $taxAmountTotal);
+
   $params = array(
     'id' => $contributionID,
     'contact_id' => $cid,
-    'total_amount' => $order_total,
-    'net_amount' => $order_total + $taxAmountTotal,
+    'total_amount' => $totalAmount,
     'tax_amount' => $taxAmountTotal,
     'source' => $notes,
     'contribution_status_id' => _compucorp_commerce_civicrm_map_contribution_status($order->status),


### PR DESCRIPTION
## Problem

If you make an order under the following configs : 

1- When Tax is configured on both Drupal and CiviCRM 
2- And for CiviCRM versions <= 4.7.11

Then the created contribution total amount will be wrong and bigger than what it is supposed to be : 

![2018-10-15 13_23_03-mail](https://user-images.githubusercontent.com/6275540/46945488-d0078800-d06c-11e8-88a1-c69679d302e8.png)
 
As you can see above, the tax amount is added twice to the total amount.  (150 +30 + 30 = 210). This happens on CiviCRM versions <= 4.7.11 because on the versions, CiviCRM recalculates the tax amount on the total amount as you can see here : https://github.com/civicrm/civicrm-core/blob/4.7.10/api/v3/Contribution.php#L85 

but since the total amount already include the tax amount then the tax will be calculated twice. This is not an issue for newer versions since that line is removed.

## Solution

I created a new function called  _compucorp_commerce_civicrm_calculateTotalAmountForCiviAPI that takes the total amount and tax amount before passing them to the contribution API, and based on the site CiviCRM version it will either pass the total amount as is or cut the tax amount from it to avoid double taxation.



I also removed the net_amount parameter from the API call to leave it for CiviCRM to calculate it.
