### PR TITLE
ASE-288: Make the created contribution a pay later if the order is in pending or processing status

### DIFF
--- a/compucorp_commerce_civicrm.module
+++ b/compucorp_commerce_civicrm.module
@@ -651,6 +651,7 @@ function _compucorp_commerce_civicrm_add_contribution($cid, &$order) {
     'contribution_status_id' => _compucorp_commerce_civicrm_map_contribution_status($order->status),
     'skipLineItem' => 1,
     'api.line_item.create' => $lineItemsParams,
+    'is_pay_later' => _compucorp_commerce_civicrm_is_pay_later($order->status),
   );
   if (!empty($tax_field_id)) {
     $params['custom_' . $tax_field_id] = $tax_total;
@@ -838,6 +839,23 @@ function _compucorp_commerce_civicrm_map_contribution_status($order_status) {
   }
 
   return $id;
+}
+
+/**
+ * Determines if the order status is "pay later"
+ * or not.
+ *
+ * @param $order_status
+ *
+ * @return bool
+ */
+function _compucorp_commerce_civicrm_is_pay_later($order_status) {
+  $payLaterStatues = array('pending', 'processing');
+  if (in_array($order_status, $payLaterStatues)) {
+    return TRUE;
+  }
+
+  return FALSE;
 }
 
 /**
@@ -1144,6 +1162,7 @@ function _compucorp_commerce_civicrm_update_contribution($order) {
     'contribution_status_id' => _compucorp_commerce_civicrm_map_contribution_status($order->status),
     'skipLineItem' => 1,
     'api.line_item.create' => $lineItemsParams,
+    'is_pay_later' => _compucorp_commerce_civicrm_is_pay_later($order->status),
   );
   if (!empty($tax_field_id)) {
     $params['custom_' . $tax_field_id] = $tax_total;


### PR DESCRIPTION
## Problem

When checking out an order, the created contribution status will follow the status of the order, if order status is for example "completed" then the contribution status will also be completed, if the order status is "pending" or "processing" then the contribution will be "pending"...etc.

But for the pending case, CiviCRM has two status for it, one called **Pending (Incomplete transaction)** and the other is **Pending (Pay Later)**, the two of these statuses are not an actual statuses since there is only one called "Pending" but Civicrm automatically either attach (Incomplete transaction) or **(Pay Later)** to the status label based on the value of **is_pay_later** field of the contribution entity, if **is_pay_later** is true then (Pay Later) will be attached to the label, otherwise (Incomplete transaction) will appear.

But for most cases when using civicrm commerce, we want pending orders to have **Pending (Pay Later)** and not **Pending (Incomplete transaction)** but currently this is not the case since is_pay_later is not touched by this module.

## Solution

I changed the contribution creation or update parameters so is_pay_later is set to True if the order status is either **Pending** or **Processing** so the created contribution status will appear as **Pending (Pay Later)**