### PR TITLE
ASE-282: Fix (simulate checkout) error

### DIFF
--- a/compucorp_commerce_civicrm.module
+++ b/compucorp_commerce_civicrm.module
@@ -489,6 +489,17 @@ function _compucorp_commerce_civicrm_add_update_contact($cid, $order) {
  * make one up and add the contribution.
  */
 function _compucorp_commerce_civicrm_add_contribution($cid, &$order) {
+  $contributionEntity = civicrm_api3('Contribution', 'get', array(
+    'sequential' => 1,
+    'return' => 'id',
+    'invoice_id' => $order->order_id . '_dc',
+    'options' => array('limit' => 1),
+  ));
+
+  if (!empty($contributionEntity['id']))  {
+    return;
+  }
+
   _compucorp_commerce_civicrm_create_custom_contribution_fields();
 
   $order_wrapper = entity_metadata_wrapper('commerce_order', $order);


### PR DESCRIPTION
## Problem

When clicking on order (simulating checkout) button, an error message saying that there is a contribution already with this ID and it refers to the contribution that was created just now in the backend of the store will be shown.

This is caused because when creating the order it triggers a checkout rule called "compucorp_commerce_civicrm_action_checkout_complete" and when we simulate the checkout it will again trigger the same rule as configured inside the civicrm-commerce module:

```
  $actions['compucorp_commerce_civicrm_action_checkout_complete'] = array(
    'group' => t('Commerce CiviCRM'),
    'label' => t('Action when checkout is complete'),
    'base' => 'compucorp_commerce_civicrm_action_checkout_complete',
    'parameter' => array(
      'commerce_order' => array('type' => 'commerce_order', 'label' => t('Order')),
    ),
  );

  $actions['compucorp_commerce_civicrm_action_order_insert'] = array(
    'group' => t('Commerce CiviCRM'),
    'label' => t('Action when creating a new order'),
    'base' => 'compucorp_commerce_civicrm_action_checkout_complete',
    'parameter' => array(
      'commerce_order' => array('type' => 'commerce_order', 'label' => t('Order')),
    ),
  );
```

1- removing this rule from "order insert" action : but this means that creating an order from drupal admin won't anymore sync records to civicrm and you will have to both create an order then to simulate the checkout to sync the records but this is not what we want since this rule is added in the first place because we wanted to records to by synced to civicrm when creating an orders from drupal side.

2- keeping the rule but adding a validation on "compucorp_commerce_civicrm_action_checkout_complete" rule code so it check if there is already a contribution associated with the order, if so then we skip syncing the records since it means that they are already synced. this can be achieved because we already store a reference for the order ID in civicrm inside the contribution invoice_id field.

## Solution

In this PR I implemented the 2nd option mentioned above, so now we check if the order already has a contribution before creating a new one.