### PR TITLE
ASESPRT-172: Add shipping rates as line item to contribution

### DIFF
--- a/compucorp_commerce_civicrm.module
+++ b/compucorp_commerce_civicrm.module
@@ -219,7 +219,12 @@ function compucorp_commerce_civicrm_action_order_update($order)  {
     return;
   }
 
-  _compucorp_commerce_civicrm_update_contribution($order);
+  // Make sure that update contribution only runs when the order is finally saved.
+  // $order->shipping_rates key is absent on final order update so we can use that to determine
+  // when we want to update contribution.
+  if (empty($order->shipping_rates)) {
+    _compucorp_commerce_civicrm_update_contribution($order);
+  }
 }
 
 /**
@@ -1043,11 +1048,6 @@ function _compucorp_commerce_civicrm_update_contribution($order) {
     $tax_total = commerce_tax_total_amount($components['components'], TRUE, commerce_default_currency()) / 100;
   }
 
-  // Fetch Shipping total.
-  if (module_exists('commerce_shipping')) {
-    $shipping_total = _compucorp_commerce_civicrm_fetch_shipping_rates($order);
-  }
-
   $products = array();
 
   // get line items and quantities
@@ -1151,6 +1151,20 @@ function _compucorp_commerce_civicrm_update_contribution($order) {
 
     $i++;
     $taxAmountTotal += $taxAmount;
+  }
+
+  // Add shipping line items to $order->shipping_rates for further calculations.
+  foreach ($order->commerce_line_items['und'] as $item) {
+    $shipping_item = commerce_line_item_load($item['line_item_id']);
+    if ($shipping_item->type === 'shipping') {
+      $shipping_service_name = $shipping_item->data['shipping_service']['name'];
+      $order->shipping_rates[$shipping_service_name] = $shipping_item;
+    }
+  }
+
+  // Fetch Shipping total.
+  if (module_exists('commerce_shipping')) {
+    $shipping_total = _compucorp_commerce_civicrm_fetch_shipping_rates($order);
   }
 
   // Adding Shipping rate as line item.


### PR DESCRIPTION
## Overview
Currently, when the order is edited, the shipping line items from the contribution are removed.
This PR makes sure that the shipping line items are still present after order update.

## Before
![ezgif com-video-to-gif(3)](https://user-images.githubusercontent.com/7393885/86084792-60913080-babb-11ea-8dde-03d8d2c679f9.gif)


## After
![ezgif com-video-to-gif(4)](https://user-images.githubusercontent.com/7393885/86085457-d8138f80-babc-11ea-86f4-90d9d3d4a8a1.gif)

## Technical Details
1. `$order->shipping_rates` is not present when editing an order which is why the line items are not added in contribution because `if (isset($order) && !empty($order->shipping_rates)) {` this condition fails.
2. In addition to above when the shipping line items are populated, the `$order->shipping_rates` is present because of which all shipping rates are added to the contribution as line item initially (before we actually click on "Save Order" button)
3. We are now updating contribution when `$order->shipping_rates` is empty and then for shipping calculations and line item creation, we are using
`  // Add shipping line items to $order->shipping_rates for further calculations.
  foreach ($order->commerce_line_items['und'] as $item) {
    $shipping_item = commerce_line_item_load($item['line_item_id']);
    if ($shipping_item->type === 'shipping') {
      $shipping_service_name = $shipping_item->data['shipping_service']['name'];
      $order->shipping_rates[$shipping_service_name] = $shipping_item;
    }
  }`