### PR TITLE
ASESPRT-222: Fix country and state province mapping from commerce to civi

### DIFF
--- a/compucorp_commerce_civicrm.module
+++ b/compucorp_commerce_civicrm.module
@@ -428,12 +428,12 @@ function _compucorp_commerce_civicrm_add_update_contact($cid, $order) {
     $params['id'] = $current_billing_location['id'];
   }
 
-  if ( ($provinceID = _compucorp_commerce_civicrm_validate_province($billing_address['administrative_area'])) !== false )  {
-    $params = array_merge($params, array( 'state_province_id'=> $provinceID));
+  if (($province = _compucorp_commerce_civicrm_get_province($billing_address)) !== null)  {
+    $params = array_merge($params, array( 'state_province_id'=> $province));
   }
 
-  if ( ($countryID = _compucorp_commerce_civicrm_validate_country($billing_address['country'])) !== false )  {
-    $params = array_merge($params, array( 'country_id'=> $countryID));
+  if (!empty($billing_address['country'])) {
+    $params = array_merge($params, array( 'country_id'=> $billing_address['country']));
   }
 
   $params['is_primary'] = 1;
@@ -472,13 +472,14 @@ function _compucorp_commerce_civicrm_add_update_contact($cid, $order) {
       $params['id'] = $current_delivery_location['id'];
     }
 
-    if ( ($provinceID = _compucorp_commerce_civicrm_validate_province($delivery_address['administrative_area'])) !== false )  {
-      $params = array_merge($params, array( 'state_province_id'=> $provinceID));
+    if (($province = _compucorp_commerce_civicrm_get_province($delivery_address)) !== null) {
+      $params = array_merge($params, array( 'state_province_id'=> $province));
     }
 
-    if ( ($countryID = _compucorp_commerce_civicrm_validate_country($delivery_address['country'])) !== false )  {
-      $params = array_merge($params, array( 'country_id'=> $countryID));
+    if (!empty($delivery_address['country'])) {
+      $params = array_merge($params, array( 'country_id'=> $delivery_address['country']));
     }
+
     // Add / update the location.
     $new_location = civicrm_api3('Address', 'create', $params);
   }
@@ -982,31 +983,45 @@ function _compucorp_commerce_civicrm_display_customer_orders($customer) {
   return $build;
 }
 
-function _compucorp_commerce_civicrm_validate_country($country)  {
-  if (!empty($country))  {
-    $allCountries = CRM_Core_PseudoConstant::countryIsoCode();
-    $result = civicrm_api3('Setting', 'get', array(
+/**
+ * Gets civicrm province name given
+ * from the given commerce address.
+ *
+ * @param array $address
+ * @param int $civicrmCountryID
+ *
+ * @return String|NULL
+ */
+function _compucorp_commerce_civicrm_get_province($address)  {
+  if (!empty($address['administrative_area'])) {
+    $country = civicrm_api3('Country', 'get', [
       'sequential' => 1,
-      'return' => "countryLimit",
-    ));
-    $countryLimit = $result['values'][0]['countryLimit'];
-    $checkCountry = array_search($country, $allCountries);
-    if ($checkCountry !== false && in_array($checkCountry, $countryLimit))  {
-      return $checkCountry;
-    }
-  }
-  return false;
-}
+      'iso_code' => $address['country'],
+    ]);
 
-function _compucorp_commerce_civicrm_validate_province($province)  {
-  if (!empty($province))  {
-    $allProvinces = CRM_Core_PseudoConstant::stateProvinceAbbreviation();
-    $checkProvince = array_search($province, $allProvinces);
-    if ($checkProvince !== false)  {
-      return $checkProvince;
+    if (empty($country['id'])) {
+      return null;
     }
+    $countryID = $country['id'];
+
+    $searchField = 'abbreviation';
+    if (strlen($address['administrative_area']) > 4) {
+      $searchField = 'name';
+    }
+
+    $stateProvince = civicrm_api3('StateProvince', 'get', [
+      'sequential' => 1,
+      'country_id' => $countryID,
+      $searchField => $address['administrative_area'],
+    ]);
+    if (empty($stateProvince['values'][0]['name'])) {
+      return null;
+    }
+
+    return $stateProvince['values'][0]['name'];
   }
-  return false;
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Before

Trying to submit commerce orders results in failure. The issue is caused because the way that it tries to map the commerce address to CiviCRM address, here is an example of how the commerce address looks like : 

![2020-07-23 02_14_27-ase  C__dev_projects_compuvag_ase  -  _sites_all_modules_custom_compucorp_comm](https://user-images.githubusercontent.com/6275540/88302048-484cb400-ccfd-11ea-854b-7d341d148815.png)


The module then send state province and the country Ids to the CiviCRM Address API after it fetch them using CiviCRM API, but the things is, the Address API accept the country abbervation and the state province full name for it to work as you can see below : 

![2020-07-23 18_06_52-CiviCRM API v3 _ ASE](https://user-images.githubusercontent.com/6275540/88303162-9dd59080-ccfe-11ea-95a4-f592097ddfe8.png)

and thus wrong values are sent to the Address API and thus it fails which results in failure during the checkout.


## After

I changed the conversion so the country is changed to its abbreviation and the state province is changed to its full name before sending them to the address API, in countries like United Kingdom where the commerce module force you to write the state province in a free text instead of a select list, the module will check if the province letters count is more than 4, if so then it will assume that you wrote the province full name, otherwise it will assume you wrote the abbreviation.