### PR TITLE
ASESPRT-172: Fix adding additional line items to existing order

### DIFF
--- a/compucorp_commerce_civicrm.module
+++ b/compucorp_commerce_civicrm.module
@@ -641,10 +641,14 @@ function _compucorp_commerce_civicrm_add_contribution($cid, &$order) {
 
   // Adding Shipping rate as line item.
   if (isset($order) && !empty($order->shipping_rates)) {
+    $defaultContributionAmountPriceFieldId = 1;
+    $defaultContributionAmountPriceFieldValueId = 1;
     $shippingFinancialTypeID = variable_get('compucorp_commerce_civicrm_shipping_financial_type');
     foreach ($order->shipping_rates as $key => $value) {
       $lineItemsParams[$i] = array (
         'label' => $value->data['shipping_service']['display_title'],
+        'price_field_id' => $defaultContributionAmountPriceFieldId,
+        'price_field_value_id' => $defaultContributionAmountPriceFieldValueId,
         'qty' => 1,
         'unit_price' => $value->data['shipping_service']['base_rate']['amount'] / 100,
         'line_total' => $value->data['shipping_service']['base_rate']['amount'] / 100,
@@ -1183,6 +1187,9 @@ function _compucorp_commerce_civicrm_update_contribution($order) {
     $taxAmount = $taxAmount['tax_amount'];
 
     $lineItemsParams[$i] = array(
+      'entity_id' => $contributionID,
+      'entity_table' => 'civicrm_contribution',
+      'contribution_id' => $contributionID,
       'label' => $values['title'],
       'price_field_id' => $priceFieldID,
       'qty' => $values['quantity'],
@@ -1217,17 +1224,55 @@ function _compucorp_commerce_civicrm_update_contribution($order) {
 
   // Adding Shipping rate as line item.
   if (isset($order) && !empty($order->shipping_rates)) {
+    $defaultContributionAmountPriceFieldId = 1;
+    $defaultContributionAmountPriceFieldValueId = 1;
     $shippingFinancialTypeID = variable_get('compucorp_commerce_civicrm_shipping_financial_type');
     foreach ($order->shipping_rates as $key => $value) {
       $lineItemsParams[$i] = array (
+        'entity_id' => $contributionID,
+        'entity_table' => 'civicrm_contribution',
+        'contribution_id' => $contributionID,
         'label' => $value->data['shipping_service']['display_title'],
+        'price_field_id' => $defaultContributionAmountPriceFieldId,
+        'price_field_value_id' => $defaultContributionAmountPriceFieldValueId,
         'qty' => 1,
         'unit_price' => $value->data['shipping_service']['base_rate']['amount'] / 100,
         'line_total' => $value->data['shipping_service']['base_rate']['amount'] / 100,
         'financial_type_id' => $shippingFinancialTypeID,
         'tax_amount' => 0,
       );
+
+      if(!empty($products[$defaultContributionAmountPriceFieldId]['id']))  {
+        $lineItemsParams[$i]['id'] = $products[$defaultContributionAmountPriceFieldId]['id'];
+      }
+
       $i++;
+    }
+  }
+
+  $i = 0;
+  foreach ($lineItemsParams as $lineItemsParam) {
+    $lineItemResponse = civicrm_api3('LineItem', 'create', $lineItemsParam);
+
+    if(!empty($lineItemResponse['id']))  {
+      $lineItemsParams[$i]['id'] = $lineItemResponse['id'];
+    }
+
+    $i++;
+  }
+
+  // Create financial Item entries.
+  $contribution = new CRM_Contribute_DAO_Contribution();
+  $contribution->id = $contributionID;
+  $contribution->find(TRUE);
+  foreach($lineItemsParams as $lineItemData) {
+    $lineItemId = $lineItemData['id'];
+    $lineItem = new CRM_Price_DAO_LineItem();
+    $lineItem->id = $lineItemId;
+    $lineItem->find(TRUE);
+    CRM_Financial_BAO_FinancialItem::add($lineItem, $contribution);
+    if (!empty((float) $contribution->tax_amount)) {
+      CRM_Financial_BAO_FinancialItem::add($lineItem, $contribution, TRUE);
     }
   }
 
@@ -1243,7 +1288,6 @@ function _compucorp_commerce_civicrm_update_contribution($order) {
     'source' => 'Drupal Order Id : ' . $order->order_id,
     'contribution_status_id' => _compucorp_commerce_civicrm_map_contribution_status($order->status),
     'skipLineItem' => 1,
-    'api.line_item.create' => $lineItemsParams,
     'is_pay_later' => _compucorp_commerce_civicrm_is_pay_later($order->status),
   );
   if (!empty($tax_field_id)) {


### PR DESCRIPTION
## Before

Adding additional line items whether they are a product line item or a shipping line item to an existing order (from the backend store) are not synced back to the contribution.

## After

Adding or deleting extra line items to the order are added back on the contribution along with the relevant financial records, and the total contribution amount is updated to match the new amount.


## Technical notes

First, shippling line items are updated to have the price field (price_field_id) and the price field value  (price_field_value_id) set to the default price set that is shipped as part CiviCRM core (called Contribution Amount with Id = 1), this to ensure that they will not get deleted by this https://github.com/compucorp/compucorp_commerce_civicrm/blob/fefc6f147ce6a2cfb76c90489ca4f0b1749a1984/compucorp_commerce_civicrm.module#L1171-L1174


and seconds, the following method _compucorp_commerce_civicrm_update_contribution is updated so it create the line items and their relevant financial records when the order is updated before updating the contribution instead of passing them as part of the Contribution Create API, the reason is that the membershipextras extension here https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/5e0c0810e4688f98e352bf1192eae360ab315eee/CRM/MembershipExtras/Hook/Pre/Contribution.php#L49
will update the contribution amount based on the current line items, and since the line items are not created yet at this point, the contribution amount will not include the added or deleted line items amounts and will remain the same.